### PR TITLE
Fix Issue where video files were being stored without blob support.

### DIFF
--- a/rfa/kaltura/configure.zcml
+++ b/rfa/kaltura/configure.zcml
@@ -17,6 +17,8 @@
   <include package=".storage" />
   
   <include package="plone.app.registry" />
+  <include package="plone.app.blob" />
+  
   <!-- Control panel -->
   <browser:page
       name="rfa-kaltura-settings"
@@ -35,5 +37,11 @@
       />
   
   <cmf:registerDirectory name="default"/>
+  
+  <!-- schema extender adapter - we will use a special file field for IKalturaVideo content types -->
+  <adapter
+    name="rfa.kaltura.file"
+    for="rfa.kaltura.interfaces.IKalturaVideo"
+    factory="rfa.kaltura.file.SchemaExtender" />
 
 </configure>

--- a/rfa/kaltura/file.py
+++ b/rfa/kaltura/file.py
@@ -1,0 +1,38 @@
+
+from zope.interface import implements
+from rfa.kaltura.storage import KalturaStorage
+from zope.i18nmessageid import MessageFactory
+_ = MessageFactory('kaltura_video')
+from Products.Archetypes.atapi import FileWidget
+from Products.validation import V_REQUIRED
+from archetypes.schemaextender.interfaces import ISchemaExtender
+
+from plone.app.blob.subtypes.file import ExtensionBlobField
+
+class SchemaExtender(object):
+    implements(ISchemaExtender)
+
+    fields = [
+        ExtensionBlobField('file',
+            required = True,
+            primary = True,
+            searchable = True,
+            accessor = 'getFile',
+            mutator = 'setFile',
+            index_method = 'getIndexValue',
+            languageIndependent = True,
+            storage = KalturaStorage(migrate=True),
+            default_content_type = 'application/octet-stream',
+            validators = (('isNonEmptyFile', V_REQUIRED),
+                          ('checkFileMaxSize', V_REQUIRED)),
+            widget = FileWidget(label = _(u'label_file', default=u'Video File'),
+                                description=_(u'Video File'),
+                                show_content_type = False,)
+            ),
+    ]
+
+    def __init__(self, context):
+        self.context = context
+
+    def getFields(self):
+        return self.fields

--- a/rfa/kaltura/storage/storage.py
+++ b/rfa/kaltura/storage/storage.py
@@ -1,8 +1,8 @@
 import tempfile
-
+import os
 from Acquisition import aq_base
-from zope.interface import implements
-from zope.interface import Interface
+from zope.interface import implements, Interface
+
 from zope.component import getUtility
 
 from plone.registry.interfaces import IRegistry
@@ -12,7 +12,6 @@ from Products.Archetypes.Storage.annotation import AnnotationStorage
 from Products.Archetypes.Registry import registerStorage
 
 from plone.app.blob.utils import openBlob
-
 
 from rfa.kaltura.kutils import kconnect
 from rfa.kaltura.kutils import kupload
@@ -31,9 +30,10 @@ class IKalturaStorage(IStorage):
     pass
 
 class KalturaStorage(AnnotationStorage):
-    """ TODO
-        Store file on kaltura media center
-        get file from kaltura media center
+    """ Designed specifically to work on the file field defined in kaltura.file
+        Works on BlobField instances from plone.app.blob
+        Connects and delivers blob binary data (videos, etc) to Kaltura as an uploaded file
+        Hands off the uploaded token to the Archetype instance to finalize creation of the KalturaEntry
     """
     implements(IKalturaStorage)
         
@@ -49,19 +49,21 @@ class KalturaStorage(AnnotationStorage):
         """Store video on Kaltura, 
            create media entry if required
         """
-        value = aq_base(value)
         initializing = kwargs.get('_initializing_', False)
         
         if initializing:
             AnnotationStorage.set(self, name, instance, value, **kwargs) 
             return
         
-        if value.filename is None:
-            #AnnotationStorage.set(self, name, instance, value, **kwargs)
+        self.value = aq_base(value)
+        if self.value.filename is None:
             return #only interested in running set when instance is ready to save.
         
         #get a filehandle for the video content we are uploading to Kaltura Server
-        fh = openBlob(value.blob, mode='r')
+        fh_blob = openBlob(self.value.blob, mode='r')
+        
+        #find the temp dir that ZODB is using.
+        tempdir = os.path.dirname(fh_blob.name)
 
         #connect to Kaltura Server
         (client, ks) = kconnect()
@@ -69,25 +71,31 @@ class KalturaStorage(AnnotationStorage):
         
         token = KalturaUploadToken()
         token = client.uploadToken.add(token)            
-        token = client.uploadToken.upload(token.getId(), fh)
+        token = client.uploadToken.upload(token.getId(), fh_blob)
         
+        fh_blob.close()
+        #instance needs to know the upload token to finalize the media entry
+        # typically, a call to Kaltura's addFromUploadedFile or updateContent services does this.
         instance.uploadToken = token
         instance.fileChanged = True
-        #now, the instance should take over to do addFromUploadedFile or updateContent
-        #and associate this uploaded file with a media entry.
         
         #if "no local storage" is set, we clobber the blob file.
         registry = getUtility(IRegistry)
         settings = registry.forInterface(IRfaKalturaSettings)
-        import pdb; pdb.set_trace()
         if settings.storageMethod == u"No Local Storage":
-            replace = tempfile
-            fh = openBlob(value.blob, mode='w') 
-            fh.write(value.filename+"\n\nThis file is stored on kaltura only, and is not available via plone")
-            fh.close()
+            filename_aside = self.makeDummyData(dir=tempdir)
+            value.blob.consumeFile(filename_aside)
 
         AnnotationStorage.set(self, name, instance, value, **kwargs)
 
+    def makeDummyData(self, dir=None):
+        if dir is None:
+            dir = tempfile.tempdir
+        fd, filename = tempfile.mkstemp(dir=dir)
+        fh = os.fdopen(fd, 'w+b')
+        fh.write(self.value.filename+"\n\nThis file is stored on kaltura only, and is not available via plone")
+        fh.close()
+        return filename
         
     def unset(self, name, instance, **kwargs):
         

--- a/rfa/kaltura/storage/storage.py
+++ b/rfa/kaltura/storage/storage.py
@@ -1,4 +1,5 @@
-import copy
+import tempfile
+
 from Acquisition import aq_base
 from zope.interface import implements
 from zope.interface import Interface
@@ -9,6 +10,9 @@ from plone.registry.interfaces import IRegistry
 from Products.Archetypes.interfaces.storage import IStorage
 from Products.Archetypes.Storage.annotation import AnnotationStorage
 from Products.Archetypes.Registry import registerStorage
+
+from plone.app.blob.utils import openBlob
+
 
 from rfa.kaltura.kutils import kconnect
 from rfa.kaltura.kutils import kupload
@@ -44,7 +48,7 @@ class KalturaStorage(AnnotationStorage):
     def set(self, name, instance, value, **kwargs):
         """Store video on Kaltura, 
            create media entry if required
-        """        
+        """
         value = aq_base(value)
         initializing = kwargs.get('_initializing_', False)
         
@@ -57,14 +61,7 @@ class KalturaStorage(AnnotationStorage):
             return #only interested in running set when instance is ready to save.
         
         #get a filehandle for the video content we are uploading to Kaltura Server
-        # Do this by creating a temporary file to write the data to, then use that file to upload                
-        #XXX Find out a way to send client.media.upload a string instead of a filehandle
-        filename = '/tmp/'+value.filename
-        with open(filename,'w') as fh:
-            fh.write(str(value))
-            
-        #re-open file in read mode
-        fh = open(filename, 'r')
+        fh = openBlob(value.blob, mode='r')
 
         #connect to Kaltura Server
         (client, ks) = kconnect()
@@ -79,13 +76,18 @@ class KalturaStorage(AnnotationStorage):
         #now, the instance should take over to do addFromUploadedFile or updateContent
         #and associate this uploaded file with a media entry.
         
-        #check to see if local storage is set
+        #if "no local storage" is set, we clobber the blob file.
         registry = getUtility(IRegistry)
         settings = registry.forInterface(IRfaKalturaSettings)
+        import pdb; pdb.set_trace()
         if settings.storageMethod == u"No Local Storage":
-            value.update_data(data = value.filename+"\nThis file is stored on kaltura only, and is not available via plone")
-            
-        AnnotationStorage.set(self, name, instance, value, **kwargs)        
+            replace = tempfile
+            fh = openBlob(value.blob, mode='w') 
+            fh.write(value.filename+"\n\nThis file is stored on kaltura only, and is not available via plone")
+            fh.close()
+
+        AnnotationStorage.set(self, name, instance, value, **kwargs)
+
         
     def unset(self, name, instance, **kwargs):
         


### PR DESCRIPTION
The fix for #71 was completely wrong.  Moving to ATCTFileField completely took blob support out of the picture, and video files were being stored in the ZODB.  (in Data.fs or your relstorage db).

Ouch.

This fixes it, by using schemaextender to apply the file field and KalturaStorage based off of ATBlob fields.

Also noticing that #70 has gone away as a happy side-effect, if there is such a thing as a happy side effect.